### PR TITLE
Add basic workflows for markdown links and code formatting

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,45 @@
+#
+# This source file is part of the  Daneshjou Lab projects
+#
+# SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: Build and Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  pylint:
+    name: PyLint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - name: Install Infrastructure
+        run: |
+          pip install -r requirements.txt
+          pip install pylint
+      - name: Analysing the code with pylint
+        run: |
+          pylint $(git ls-files '*.py')
+  black_lint:
+    name: Black Code Formatter Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - name: Install Black
+        run: pip install black[jupyter]
+      - name: Check code formatting with Black
+        run: black . --exclude '\.ipynb$'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,10 +15,10 @@ on:
 jobs:
   reuse_action:
     name: REUSE Compliance Check
-    uses: PathReportParsing_MRA_DeepDerm/.github/.github/workflows/reuse.yml@v2
+    uses: DaneshjouLab/.github/.github/workflows/reuse.yml@main
   markdown_link_check:
     name: Markdown Link Check
-    uses: DaneshjouLab/.github/.github/workflows/markdown-link-check.yml@v2
+    uses: DaneshjouLab/.github/.github/workflows/markdown-link-check.yml@main
   yamllint:
     name: YAML Lint Check
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,37 @@
+#
+# This source file is part of the Daneshjou Lab projects
+#
+# SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: Pull Request
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  reuse_action:
+    name: REUSE Compliance Check
+    uses: PathReportParsing_MRA_DeepDerm/.github/.github/workflows/reuse.yml@v2
+  markdown_link_check:
+    name: Markdown Link Check
+    uses: DaneshjouLab/.github/.github/workflows/markdown-link-check.yml@v2
+  yamllint:
+    name: YAML Lint Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+
+      - name: Install yamllint
+        run: pip install yamllint
+
+      - name: Run yamllint with custom config
+        run: yamllint -c .yamllint .github/workflows/*.yml

--- a/.reuse/dep5.txt
+++ b/.reuse/dep5.txt
@@ -1,0 +1,6 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+
+Files: tests/*
+Copyright: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+License: MIT
+Comment: All files are part of the Daneshjou Lab projects.


### PR DESCRIPTION
# *Add basic workflows for markdown links and code formatting*

## :recycle: Current Situation & Problem
- This PR introduces basic `GitHub` workflows to our repository to automate the checking of markdown links and enforce code formatting and linting standards using `Black` and `Pylint`.
- This is an enhancement to our existing repository infrastructure.
- This PR addresses the need for maintaining high code quality and ensuring that all documentation links are functional.

## :gear: Release Notes 
- Added a `GitHub` workflow for checking markdown links in documents to catch any broken links automatically.
- Integrated `Black` for code formatting and `Pylint` for code analysis to ensure coding standards are met.

## :books: Documentation
N/A

## :chart_with_upwards_trend: Model Metrics & Performance
N/A

## :white_check_mark: Testing
N/A

## :hammer_and_wrench: Training & Environment Setup
N/A

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting this pull request, you agree to follow our [Coding Guidelines](https://github.com/DaneshjouLab/.github/blob/main/CODING_GUIDELINES.md):
- [x] I agree to follow the [Coding Guidelines](https://github.com/DaneshjouLab/.github/blob/main/CODING_GUIDELINES.md).
